### PR TITLE
ci: fix lint config to v2 format

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,45 +1,67 @@
 version: "2"
-linters-settings:
-  gocyclo:
-    min-complexity: 10
-  dupl:
-    threshold: 100
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  depguard:
-    rules:
-      main:
-        deny:
-          - pkg: "github.com/sirupsen/logrus"
-            desc: logging is allowed only by logutils.Log, logrus, is allowed to use only in logutils package
-  lll:
-    line-length: 140
-  goimports:
-    local-prefixes: github.com/apache/dubbo-go-extensions
-  gocritic:
-    enabled-tags:
-      - performance
-      - style
-      - experimental
-    disabled-checks:
-      - wrapperFunc
 
-linters:
-  disable-all: true
-  enable:
-    - staticcheck
-    - ineffassign
-    - misspell
+run:
+  timeout: 20m
 
 issues:
-  exclude-dirs:
-    - test/testdata_etc
-    - pkg/golinters/goanalysis/(checker|passes)
-  exclude-rules:
-    - text: "weak cryptographic primitive"
-      linters:
-        - gosec
-    - linters:
-        - staticcheck
-      text: "SA1019:"
+  new: true
+
+linters:
+  default: none
+  enable:
+    - govet
+    - ineffassign
+    - misspell
+    - staticcheck
+    - depguard
+
+  settings:
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: github.com/sirupsen/logrus
+              desc: logging is allowed only by logutils.Log, logrus is allowed only in logutils package
+
+    dupl:
+      threshold: 100
+
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+
+    gocritic:
+      disabled-checks:
+        - wrapperFunc
+      enabled-tags:
+        - performance
+        - style
+        - experimental
+
+    lll:
+      line-length: 140
+
+  exclusions:
+    rules:
+      - linters:
+          - gosec
+        text: weak cryptographic primitive
+      - linters:
+          - staticcheck
+        text: "SA1019:"
+    paths:
+      - test/testdata_etc
+      - pkg/golinters/goanalysis/(checker|passes)
+
+formatters:
+  enable:
+    - gofmt
+  settings:
+    gofmt:
+      simplify: true
+      rewrite-rules:
+        - pattern: interface{}
+          replacement: any
+    goimports:
+      local-prefixes:
+        - github.com/golangci/golangci-lint


### PR DESCRIPTION
## Description
update `.golangci.yml` to the golangci-lint v2 configuration format and disable the `goimports` formatter.

### Changes
migrate `.golangci.yml` to golangci-lint v2 config format
disable the `goimports` formatter in golangci-lint
keep import formatting handled by `imports-formatter` in the CI pipeline